### PR TITLE
bumping ruby to 2.3.0, abstracting version to variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,30 @@
 FROM heroku/cedar:14
 MAINTAINER Terence Lee <terence@heroku.com>
 
+ENV RUBY_VERSION 2.3.0
+ENV NODE_VERSION 0.12.7
+ENV BUNDLER_VERSION 1.9.10
+
 RUN mkdir -p /app/user
 WORKDIR /app/user
 
-ENV GEM_PATH /app/heroku/ruby/bundle/ruby/2.2.0
-ENV GEM_HOME /app/heroku/ruby/bundle/ruby/2.2.0
-RUN mkdir -p /app/heroku/ruby/bundle/ruby/2.2.0
+ENV GEM_PATH /app/heroku/ruby/bundle/ruby/$RUBY_VERSION
+ENV GEM_HOME /app/heroku/ruby/bundle/ruby/$RUBY_VERSION
+RUN mkdir -p /app/heroku/ruby/bundle/ruby/$RUBY_VERSION
 
 # Install Ruby
-RUN mkdir -p /app/heroku/ruby/ruby-2.2.3
-RUN curl -s --retry 3 -L https://heroku-buildpack-ruby.s3.amazonaws.com/cedar-14/ruby-2.2.3.tgz | tar xz -C /app/heroku/ruby/ruby-2.2.3
-ENV PATH /app/heroku/ruby/ruby-2.2.3/bin:$PATH
+RUN mkdir -p /app/heroku/ruby/ruby-$RUBY_VERSION
+RUN curl -s --retry 3 -L https://heroku-buildpack-ruby.s3.amazonaws.com/cedar-14/ruby-$RUBY_VERSION.tgz | tar xz -C /app/heroku/ruby/ruby-$RUBY_VERSION
+ENV PATH /app/heroku/ruby/ruby-$RUBY_VERSION/bin:$PATH
 
 # Install Node
-RUN curl -s --retry 3 -L http://s3pository.heroku.com/node/v0.12.7/node-v0.12.7-linux-x64.tar.gz | tar xz -C /app/heroku/ruby/
-RUN mv /app/heroku/ruby/node-v0.12.7-linux-x64 /app/heroku/ruby/node-0.12.7
-ENV PATH /app/heroku/ruby/node-0.12.7/bin:$PATH
+RUN curl -s --retry 3 -L http://s3pository.heroku.com/node/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz | tar xz -C /app/heroku/ruby/
+RUN mv /app/heroku/ruby/node-v$NODE_VERSION-linux-x64 /app/heroku/ruby/node-$NODE_VERSION
+ENV PATH /app/heroku/ruby/node-$NODE_VERSION/bin:$PATH
 
 # Install Bundler
-RUN gem install bundler -v 1.9.10 --no-ri --no-rdoc
-ENV PATH /app/user/bin:/app/heroku/ruby/bundle/ruby/2.2.0/bin:$PATH
+RUN gem install bundler -v $BUNDLER_VERSION --no-ri --no-rdoc
+ENV PATH /app/user/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:$PATH
 ENV BUNDLE_APP_CONFIG /app/heroku/ruby/.bundle/config
 
 # Run bundler to cache dependencies

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This image is for use with Heroku Docker CLI.
 Your project must contain the following files:
 
 * `Gemfile` and `Gemfile.lock`
-* Ruby 2.2.3
+* Ruby 2.3.0
 * `assets:precompile` rake task
 * `Procfile` (see [the Heroku Dev Center for details](https://devcenter.heroku.com/articles/procfile))
 


### PR DESCRIPTION
**Changes implemented**
- Abstracted version information to `ENV` variables.
  - I know this may seem like overkill, but it makes updates so much easier and reduces chance for errors when updating
- Bumped Ruby's version to `2.3.0` in `Dockerfile`
- Bumped Ruby's "base" version -- for `GEM_PATH`, etc. -- to `2.3.0`
  - I created a separate `ENV` variable for this based off `RUBY_MAJOR` and `RUBY_MINOR`, to ensure that this will change automatically when updating versions in the future
- Bumped the reference Ruby's version to `2.3.0` in `README.md`

**Recommended, but not implemented**

I would recommend bumping `node` to the latest LTS release, [currently `4.2.4`](https://nodejs.org/en/blog/release/v4.2.4/). I'm happy to include that in this PR if desired, but didn't want to muddy the waters (so to speak).

Cheers!
